### PR TITLE
Fix electrodes comment, add units waveform mean

### DIFF
--- a/HCK08/ecephys_tutorial.ipynb
+++ b/HCK08/ecephys_tutorial.ipynb
@@ -526,18 +526,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "io = NWBHDF5IO('ecephys_tutorial.nwb', 'r')\n",
-    "file = io.read()\n",
-    "print(file)\n",
-    "io.close()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/HCK08/ecephys_tutorial.ipynb
+++ b/HCK08/ecephys_tutorial.ipynb
@@ -314,7 +314,7 @@
    "outputs": [],
    "source": [
     "nwbfile.add_electrode_column(name='label', description='label of electrode')\n",
-    "shank_channels = [4, 3]  # set up 4 shanks with 3 electrodes each\n",
+    "shank_channels = [4, 3]  # set up two shanks, the first with 4 electrodes and the second with 3 electrodes\n",
     "\n",
     "electrode_counter = 0\n",
     "device = nwbfile.create_device('array')\n",
@@ -457,7 +457,7 @@
     "for n_units_per_shank in range(n_units):\n",
     "    n_spikes = np.random.poisson(lam=poisson_lambda)\n",
     "    spike_times = np.round(np.cumsum(np.random.exponential(1/firing_rate, n_spikes)), 5)\n",
-    "    nwbfile.add_unit(spike_times=spike_times, quality='good')\n",
+    "    nwbfile.add_unit(spike_times=spike_times, quality='good', waveform_mean=[1, 2, 3, 4, 5])\n",
     "\n",
     "nwbfile.units.to_dataframe()"
    ]
@@ -523,6 +523,18 @@
     "    print('')\n",
     "    print('spike times from 0th unit:')\n",
     "    print(read_nwbfile.units['spike_times'][0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "io = NWBHDF5IO('ecephys_tutorial.nwb', 'r')\n",
+    "file = io.read()\n",
+    "print(file)\n",
+    "io.close()"
    ]
   },
   {


### PR DESCRIPTION
The comment for the shank_channels variable was wrong and confused a user. This PR fixes that.

This PR also adds a waveform mean when calling `nwbfile.add_unit` which was a question during the tutorial. 