### PR TITLE
Add matplotlib install instructions in tutorial

### DIFF
--- a/HCK09/pynwb_read_demo.ipynb
+++ b/HCK09/pynwb_read_demo.ipynb
@@ -44,7 +44,11 @@
     "\n",
     "First, install PyNWB using `pip` or `conda`. You will need Python 3.5+ installed.\n",
     "- `pip install -U pynwb`\n",
-    "- `conda install -c conda-forge pynwb` "
+    "- `conda install -c conda-forge pynwb`\n",
+    "\n",
+    "In addition you will need `matplotlib` later on for the generation of plots. This can also be installed via `pip` or `conda`\n",
+    "- `pip install -U matplotlib`\n",
+    "- `conda install matplotlib`"
    ]
   },
   {


### PR DESCRIPTION
This might help inexperienced users to complete the tutorial in case they are starting in a bare python environment without matplotlib.